### PR TITLE
Update CI to new pattern, add next steps section to README.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,12 +36,11 @@ jobs:
 
   check_schema:
     name: Check Schema with Apollo Studio
+    if: false
     needs: [ test ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-      APOLLO_GRAPH_REF: ${{ secrets.APOLLO_GRAPH_REF }}
       # rename this to a valid subgraph name
       SUBGRAPH_NAME: foo-bar
     steps:
@@ -53,11 +52,6 @@ jobs:
           curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
       - name: Schema Check
-        if: env.APOLLO_KEY != '' &&  env.APOLLO_GRAPH_REF != ''
         run: rover subgraph check ${{ secrets.APOLLO_GRAPH_REF }} --schema ${{ needs.test.outputs.schema }} --name ${{ env.SUBGRAPH_NAME }}
-      - name: APOLLO_KEY is not set
-        if: env.APOLLO_KEY == ''
-        run: echo "::warning file=.github/workflows/checks.yaml,line=54,col=1,endColumn=1::No Apollo Studio Api Key is set in repository. Set this in the repository secrets under APOLLO_KEY"
-      - name: APOLLO_GRAPH_REF is not set
-        if: env.APOLLO_GRAPH_REF == ''
-        run: echo "::warning file=.github/workflows/checks.yaml,line=54,col=1,endColumn=1::No Apollo Studio Graph Name is set in repository. Set this in the repository secrets under APOLLO_GRAPH_REF"
+        env:
+          APOLLO_KEY: ${{ secrets.APOLLO_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,12 +45,10 @@ jobs:
 
   publish_schema:
     name: Publish new schema to Apollo Studio
+    if: false
     needs: [ deploy ]
     env:
       APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-      APOLLO_GRAPH_REF: ${{ secrets.APOLLO_GRAPH_REF }}
-      PRODUCTION_URL: ${{ secrets.PRODUCTION_URL }}
       # rename this to a valid subgraph name
       SUBGRAPH_NAME: foo-bar
     runs-on: ubuntu-latest
@@ -63,14 +61,6 @@ jobs:
           curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
       - name: Publish Schema
-        if: env.APOLLO_KEY != '' &&  env.APOLLO_GRAPH_REF != '' && env.PRODUCTION_URL != ''
         run: rover subgraph publish ${{ secrets.APOLLO_GRAPH_REF }} --schema ${{ needs.prepare_schema.outputs.schema }} --name ${{ env.SUBGRAPH_NAME }} --routing-url ${{ secrets.PRODUCTION_URL }}
-      - name: APOLLO_KEY is not set
-        if: env.APOLLO_KEY == ''
-        run: echo "::warning file=.github/workflows/deploy.yaml,line=65,col=1,endColumn=1::No Apollo Studio Api Key is set in repository. Set this in the repository secrets under APOLLO_KEY"
-      - name: APOLLO_GRAPH_REF is not set
-        if: env.APOLLO_GRAPH_REF == ''
-        run: echo "::warning file=.github/workflows/deploy.yaml,line=65,col=1,endColumn=1::No Apollo Studio Graph Name is set in repository. Set this in the repository secrets under APOLLO_GRAPH_REF"
-      - name: PRODUCTION_URL is not set
-        if: env.PRODUCTION_URL == ''
-        run: echo "::warning file=.github/workflows/deploy.yaml,line=65,col=1,endColumn=1::No Production URL is set in repository. Set this in the repository secrets under PRODUCTION_URL"
+        env:
+          APOLLO_KEY: ${{ secrets.APOLLO_KEY }}

--- a/README.md
+++ b/README.md
@@ -76,7 +76,18 @@ To start the GraphQL server:
 ./gradlew bootRun
 ```
 
-Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground.
+Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground and begin developing your supergraph with `rover dev --url http://localhost:8080/graphql --name my-sugraph`.
+
+## Apollo Studio Integration
+
+1. Set these secrets in GitHub Actions:
+    1. APOLLO_KEY: An Apollo Studio API key for the supergraph to enable schema checks and publishing of the
+       subgraph.
+    2. APOLLO_GRAPH_REF: The name of the supergraph in Apollo Studio.
+    3. PRODUCTION_URL: The URL of the deployed subgraph that the supergraph gateway will route to.
+2. Set `SUBGRAPH_NAME` in .github/workflows/checks.yaml and .github/workflows/deploy.yaml
+3. Remove the `if: false` lines from `.github/workflows/checks.yaml` and `.github/workflows/deploy.yaml` to enable schema checks and publishing.
+4. Write your custom deploy logic in `.github/workflows/deploy.yaml`.
 
 ## Additional Resources
 


### PR DESCRIPTION
We're swapping to this new format for disabling checks/publish because it leaves less residue for the user to clean up.

I also added some explicit next steps and mentioned how to use `rover dev` (which we expect to be a go-to development flow for templates).