### PR TITLE
feat: Add boilerplate for enforcing Router authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Once the app has started you can explore the example schema by opening the Graph
 2. Set `SUBGRAPH_NAME` in .github/workflows/checks.yaml and .github/workflows/deploy.yaml
 3. Remove the `if: false` lines from `.github/workflows/checks.yaml` and `.github/workflows/deploy.yaml` to enable schema checks and publishing.
 4. Write your custom deploy logic in `.github/workflows/deploy.yaml`.
+5. Send the `Router-Authorization` header [from your Cloud router](https://www.apollographql.com/docs/graphos/routing/cloud-configuration#managing-secrets) and set the `ROUTER_SECRET` environment variable wherever you deploy this to.
 
 ## Additional Resources
 

--- a/src/main/kotlin/com/example/template/RouterAuthFilter.kt
+++ b/src/main/kotlin/com/example/template/RouterAuthFilter.kt
@@ -1,0 +1,32 @@
+package com.example.template
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+/**
+ * If the ROUTER_SECRET environment variable is set, then this filter will require that all requests have a `Router-Authorization`
+ * header matching that value.
+ *
+ */
+@Component
+class RouterAuthFilter : WebFilter {
+    override fun filter(ctx: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        val secret = System.getenv("ROUTER_SECRET")
+        return if (secret != null) {
+            val authHeader = ctx.request.headers.getFirst("Router-Authorization")
+            if (authHeader == secret) {
+                chain.filter(ctx)
+            } else {
+                ctx.response.statusCode = HttpStatus.UNAUTHORIZED
+                Mono.empty()
+            }
+        } else {
+            chain.filter(ctx)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/example/template/RouterAuthFilter.kt
+++ b/src/main/kotlin/com/example/template/RouterAuthFilter.kt
@@ -8,8 +8,8 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 
 /**
- * If the ROUTER_SECRET environment variable is set, then this filter will require that all requests have a `Router-Authorization`
- * header matching that value.
+ * If the ROUTER_SECRET environment variable is set, then this filter will require that all requests have
+ * a `Router-Authorization` header matching that value.
  *
  */
 @Component


### PR DESCRIPTION
This works, from my testing, but I don't know if it's the best way to enforce this. This pattern (using a header to validate that requests are only coming from the router) is generally being added to all the templates since we want to push harder for serverless subgraphs to be secured.